### PR TITLE
[release-2.7] Recover owner references that are removed from policy t…

### DIFF
--- a/controllers/templatesync/template_sync.go
+++ b/controllers/templatesync/template_sync.go
@@ -439,6 +439,7 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 
 		for _, ownerref := range eObject.GetOwnerReferences() {
 			refName = ownerref.Name
+
 			break // just get the first ownerReference, if there are any at all
 		}
 

--- a/controllers/templatesync/template_sync.go
+++ b/controllers/templatesync/template_sync.go
@@ -36,8 +36,9 @@ import (
 )
 
 const (
-	ControllerName string = "policy-template-sync"
-	policyFmtStr   string = "policy: %s/%s"
+	ControllerName    string = "policy-template-sync"
+	policyFmtStr      string = "policy: %s/%s"
+	parentPolicyLabel string = "policy.open-cluster-management.io/policy"
 )
 
 var log = ctrl.Log.WithName(ControllerName)
@@ -351,6 +352,9 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 					Kind:    policiesv1.Kind,
 				})
 				labels := tObjectUnstructured.GetLabels()
+
+				// set label to identify parent policy for this template
+				labels[parentPolicyLabel] = instance.GetName()
 
 				if labels == nil {
 					labels = map[string]string{

--- a/test/e2e/case16_restore_owner_refs_test.go
+++ b/test/e2e/case16_restore_owner_refs_test.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2020 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"open-cluster-management.io/governance-policy-propagator/test/utils"
+)
+
+var _ = Describe("Test owner reference recovery", func() {
+	const (
+		case16PolicyName            string = "case16-test-policy"
+		case16PolicyYaml            string = "../resources/case16_restore_owner_refs/case16-test-policy.yaml"
+		case16ConfigPolicyName      string = "case16-config-policy"
+		case16PatchConfigPolicyYaml string = "../resources/case16_restore_owner_refs/case16-patch-configpolicy.yaml"
+	)
+
+	BeforeEach(func() {
+		By("Creating a policy on the hub in ns:" + clusterNamespaceOnHub)
+		_, err := kubectlHub("apply", "-f", case16PolicyYaml, "-n", clusterNamespaceOnHub)
+		Expect(err).Should(BeNil())
+		plc := utils.GetWithTimeout(clientManagedDynamic, gvrPolicy, case16PolicyName, clusterNamespace, true,
+			defaultTimeoutSeconds)
+		Expect(plc).NotTo(BeNil())
+	})
+	AfterEach(func() {
+		By("Deleting a policy on the hub in ns:" + clusterNamespaceOnHub)
+		_, err := kubectlHub("delete", "-f", case16PolicyYaml, "-n", clusterNamespaceOnHub, "--ignore-not-found=true")
+		Expect(err).To(BeNil())
+		opt := metav1.ListOptions{}
+		utils.ListWithTimeout(clientManagedDynamic, gvrPolicy, opt, 0, true, defaultTimeoutSeconds)
+	})
+	It("Should restore owner references that are edited out of the child config policy", func() {
+		By("Patching config policy to remove owner references")
+		_, err := kubectlManaged("patch", "configurationpolicy", case16ConfigPolicyName, "-n", clusterNamespace,
+			"--type", "merge", "--patch-file", case16PatchConfigPolicyYaml)
+		Expect(err).Should(BeNil())
+
+		Eventually(func() interface{} {
+			configPlc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigurationPolicy,
+				case16ConfigPolicyName, clusterNamespace, true, defaultTimeoutSeconds)
+
+			md, ok := configPlc.Object["metadata"].(map[string]interface{})
+			if !ok {
+				return nil
+			}
+			ownerRefs, ok := md["ownerReferences"]
+			if !ok {
+				return nil
+			}
+
+			return ownerRefs.([]interface{})[0].(map[string]interface{})["name"]
+		}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(case16PolicyName))
+	})
+})

--- a/test/resources/case16_restore_owner_refs/case16-patch-configpolicy.yaml
+++ b/test/resources/case16_restore_owner_refs/case16-patch-configpolicy.yaml
@@ -1,0 +1,2 @@
+metadata:
+  ownerReferences: []

--- a/test/resources/case16_restore_owner_refs/case16-test-policy.yaml
+++ b/test/resources/case16_restore_owner_refs/case16-test-policy.yaml
@@ -1,0 +1,30 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: case16-test-policy
+  labels:
+    policy.open-cluster-management.io/cluster-name: managed
+    policy.open-cluster-management.io/cluster-namespace: managed
+    policy.open-cluster-management.io/root-policy: case16-test-policy
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: case16-config-policy
+        spec:
+          remediationAction: inform
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Pod
+                metadata:
+                  name: nginx-pod-e2e
+                  namespace: default
+                spec:
+                  containers:
+                    - name: nginx


### PR DESCRIPTION
…emplates

Previously if the owner references array was removed from the metadata of a policy template, there was no way to recoveer them. With recent commits this no longer caused an index out of bounds panic, but we still want to keep the owner references, so this PR adds code to restore them if they are removed.

refs: https://issues.redhat.com/browse/ACM-3027

Backport of https://github.com/open-cluster-management-io/governance-policy-framework-addon/pull/30/files