### PR TITLE
Manual sync of PRs #30-32, 34 (#37)

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -53,8 +53,8 @@ rules:
   resources:
   - customresourcedefinitions
   verbs:
-  - get
   - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/deploy/rbac/role.yaml
+++ b/deploy/rbac/role.yaml
@@ -11,8 +11,8 @@ rules:
   resources:
   - customresourcedefinitions
   verbs:
-  - get
   - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/test/e2e/case16_restore_owner_refs_test.go
+++ b/test/e2e/case16_restore_owner_refs_test.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2020 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"open-cluster-management.io/governance-policy-propagator/test/utils"
+)
+
+var _ = Describe("Test owner reference recovery", func() {
+	const (
+		case16PolicyName            string = "case16-test-policy"
+		case16PolicyYaml            string = "../resources/case16_restore_owner_refs/case16-test-policy.yaml"
+		case16ConfigPolicyName      string = "case16-config-policy"
+		case16PatchConfigPolicyYaml string = "../resources/case16_restore_owner_refs/case16-patch-configpolicy.yaml"
+	)
+
+	BeforeEach(func() {
+		By("Creating a policy on the hub in ns:" + clusterNamespaceOnHub)
+		_, err := kubectlHub("apply", "-f", case16PolicyYaml, "-n", clusterNamespaceOnHub)
+		Expect(err).Should(BeNil())
+		plc := utils.GetWithTimeout(clientManagedDynamic, gvrPolicy, case16PolicyName, clusterNamespace, true,
+			defaultTimeoutSeconds)
+		Expect(plc).NotTo(BeNil())
+	})
+	AfterEach(func() {
+		By("Deleting a policy on the hub in ns:" + clusterNamespaceOnHub)
+		_, err := kubectlHub("delete", "-f", case16PolicyYaml, "-n", clusterNamespaceOnHub, "--ignore-not-found=true")
+		Expect(err).To(BeNil())
+		opt := metav1.ListOptions{}
+		utils.ListWithTimeout(clientManagedDynamic, gvrPolicy, opt, 0, true, defaultTimeoutSeconds)
+	})
+	It("Should restore owner references that are edited out of the child config policy", func() {
+		By("Patching config policy to remove owner references")
+		_, err := kubectlManaged("patch", "configurationpolicy", case16ConfigPolicyName, "-n", clusterNamespace,
+			"--type", "merge", "--patch-file", case16PatchConfigPolicyYaml)
+		Expect(err).Should(BeNil())
+
+		Eventually(func() interface{} {
+			configPlc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigurationPolicy,
+				case16ConfigPolicyName, clusterNamespace, true, defaultTimeoutSeconds)
+
+			md, ok := configPlc.Object["metadata"].(map[string]interface{})
+			if !ok {
+				return nil
+			}
+			ownerRefs, ok := md["ownerReferences"]
+			if !ok {
+				return nil
+			}
+
+			return ownerRefs.([]interface{})[0].(map[string]interface{})["name"]
+		}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(case16PolicyName))
+	})
+})

--- a/test/resources/case16_restore_owner_refs/case16-patch-configpolicy.yaml
+++ b/test/resources/case16_restore_owner_refs/case16-patch-configpolicy.yaml
@@ -1,0 +1,2 @@
+metadata:
+  ownerReferences: []

--- a/test/resources/case16_restore_owner_refs/case16-test-policy.yaml
+++ b/test/resources/case16_restore_owner_refs/case16-test-policy.yaml
@@ -1,0 +1,31 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: case16-test-policy
+  labels:
+    policy.open-cluster-management.io/cluster-name: managed
+    policy.open-cluster-management.io/cluster-namespace: managed
+    policy.open-cluster-management.io/root-policy: case16-test-policy
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: case16-config-policy
+        spec:
+          remediationAction: inform
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Pod
+                metadata:
+                  name: nginx-pod-e2e
+                  namespace: default
+                spec:
+                  containers:
+                    - name: nginx
+


### PR DESCRIPTION
* Remove get permission for CRDs

https://github.com/open-cluster-management-io/governance-policy-framework-addon/pull/28 added get and list permissions for CRDs, but only list is used. This PR updates the cluster role so it doesn't have the extra get permission.


(cherry picked from commit a491bbe38b4e2083a0e6f1183a641dcde569ba44)

* Add watch for CRD to role


(cherry picked from commit d885a7c2a9a1b9835af03538bef0f28ceaa3e6a1)

* Recover owner references that are removed from policy templates

Previously if the owner references array was removed from the metadata of a policy template, there was no way to recoveer them. With recent commits this no longer caused an index out of bounds panic, but we still want to keep the owner references, so this PR adds code to restore them if they are removed.

refs: https://issues.redhat.com/browse/ACM-3027


(cherry picked from commit 71060291f19b05c47f25f345d0cc8b944963ceec)

* Remove the dependency watches when a policy is deleted

This will prevent unnecessary reconciles for dependency updates after the policy that defined the dependencies is deleted.


(cherry picked from commit 1048a8040d8a20bddec82b1afed3f89a26560198)

---------