### PR TITLE
ACM-3160: Invalid policy-templates array syntax leads to policy_system_errors_total incrementing

### DIFF
--- a/controllers/templatesync/template_sync.go
+++ b/controllers/templatesync/template_sync.go
@@ -416,7 +416,12 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 					r.emitTemplateError(instance, tIndex, tName, errMsg)
 					tLogger.Error(resultError, "Failed to create policy template")
 
-					policySystemErrorsCounter.WithLabelValues(instance.Name, tName, "create-error").Inc()
+					// check for syntax error in policy
+					if errors.IsInvalid(err) {
+						policyUserErrorsCounter.WithLabelValues(instance.Name, tName, "format-error").Inc()
+					} else {
+						policySystemErrorsCounter.WithLabelValues(instance.Name, tName, "create-error").Inc()
+					}
 
 					continue
 				}
@@ -557,7 +562,12 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 				r.emitTemplateError(instance, tIndex, tName, errMsg)
 				tLogger.Error(err, "Failed to update the policy template")
 
-				policySystemErrorsCounter.WithLabelValues(instance.Name, tName, "patch-error").Inc()
+				// check for syntax error in policy
+				if errors.IsInvalid(err) {
+					policyUserErrorsCounter.WithLabelValues(instance.Name, tName, "format-error").Inc()
+				} else {
+					policySystemErrorsCounter.WithLabelValues(instance.Name, tName, "patch-error").Inc()
+				}
 
 				continue
 			}

--- a/test/e2e/case17_syntax_error_metric_test.go
+++ b/test/e2e/case17_syntax_error_metric_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2020 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package e2e
+
+import (
+	"strconv"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	policyUtils "open-cluster-management.io/governance-policy-propagator/test/utils"
+
+	"open-cluster-management.io/governance-policy-framework-addon/test/utils"
+)
+
+var _ = Describe("Test proper metrics handling on syntax error", Ordered, func() {
+	userMetricName := "policy_user_errors_total"
+	policyName := "case17-policy"
+	errPolicyFile := "../resources/case17/case17-test-policy-err.yaml"
+	correctPolicyFile := "../resources/case17/case17-test-policy.yaml"
+
+	cleanup := func() {
+		By("Deleting a policy on hub cluster in ns:" + clusterNamespaceOnHub)
+		// Clean up and ignore any errors (in case it was deleted previously)
+		_, _ = kubectlHub("delete", "-f", errPolicyFile, "-n", clusterNamespaceOnHub)
+		opt := metav1.ListOptions{}
+		policyUtils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 0, true, defaultTimeoutSeconds)
+		policyUtils.ListWithTimeout(clientManagedDynamic, gvrPolicy, opt, 0, true, defaultTimeoutSeconds)
+	}
+
+	AfterAll(cleanup)
+
+	It("Should increment user error metric when attempting to apply policy with syntax error", func() {
+		hubApplyPolicy(policyName, errPolicyFile)
+
+		By("Checking for the " + userMetricName + " metric on the template-sync controller")
+		values := []string{}
+		Eventually(func() []string {
+			values = utils.GetMetrics(userMetricName, policyName)
+
+			return values
+		}, defaultTimeoutSeconds, 1).Should(HaveLen(1))
+		Expect(strconv.Atoi(values[0])).To(BeNumerically(">=", 1))
+	})
+
+	It("Should clean up user error metric on policy deletion", func() {
+		By(
+			"Deleting policy " + policyName + " on hub cluster " +
+				"in ns:" + clusterNamespaceOnHub,
+		)
+		cleanup()
+		By("Checking for the " + userMetricName + " metric on the template-sync controller")
+		values := []string{}
+		Eventually(func() []string {
+			values = utils.GetMetrics(userMetricName, policyName)
+
+			return values
+		}, defaultTimeoutSeconds, 1).Should(HaveLen(0))
+	})
+
+	It("Should increment user error metric when patching a correct policy with a syntax error", func() {
+		hubApplyPolicy(policyName, correctPolicyFile)
+		hubApplyPolicy(policyName, errPolicyFile)
+
+		By("Checking for the " + userMetricName + " metric on the template-sync controller")
+		values := []string{}
+		Eventually(func() []string {
+			values = utils.GetMetrics(userMetricName, policyName)
+
+			return values
+		}, defaultTimeoutSeconds, 1).Should(HaveLen(1))
+		Expect(strconv.Atoi(values[0])).To(BeNumerically(">=", 1))
+	})
+})

--- a/test/resources/case17/case17-test-policy-err.yaml
+++ b/test/resources/case17/case17-test-policy-err.yaml
@@ -1,0 +1,20 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: case17-policy
+  labels:
+    policy.open-cluster-management.io/cluster-name: managed
+    policy.open-cluster-management.io/cluster-namespace: managed
+    policy.open-cluster-management.io/root-policy: case17-policy
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: case17-configpolicy
+        spec:
+          remediationAction: inform
+          object-templates: false # syntax error

--- a/test/resources/case17/case17-test-policy.yaml
+++ b/test/resources/case17/case17-test-policy.yaml
@@ -1,0 +1,30 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: case17-policy
+  labels:
+    policy.open-cluster-management.io/cluster-name: managed
+    policy.open-cluster-management.io/cluster-namespace: managed
+    policy.open-cluster-management.io/root-policy: case17-policy
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: case17-configpolicy
+        spec:
+          remediationAction: inform
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Pod
+                metadata:
+                  name: nginx-pod-e2e
+                  namespace: default
+                spec:
+                  containers:
+                    - name: nginx


### PR DESCRIPTION
**Description of problem:** Even when a syntactically incorrect policy is applied, `policy_system_errors_total` increments instead of `policy_user_errors_total`.

**Solution:** Added simple checks where needed to check for syntax error in order to determine which metric to increment.

**Ref:** https://issues.redhat.com/browse/ACM-3160