### PR TITLE
ACM-3160: Invalid policy-templates array syntax leads to policy_system_errors_total incrementing

### DIFF
--- a/controllers/templatesync/template_sync.go
+++ b/controllers/templatesync/template_sync.go
@@ -563,7 +563,12 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 
 					tLogger.Error(resultError, "Failed to create policy template")
 
-					policySystemErrorsCounter.WithLabelValues(instance.Name, tName, "create-error").Inc()
+					// check for syntax error in policy
+					if k8serrors.IsInvalid(err) {
+						policyUserErrorsCounter.WithLabelValues(instance.Name, tName, "format-error").Inc()
+					} else {
+						policySystemErrorsCounter.WithLabelValues(instance.Name, tName, "create-error").Inc()
+					}
 
 					continue
 				}
@@ -756,7 +761,12 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 
 				tLogger.Error(err, "Failed to update the policy template")
 
-				policySystemErrorsCounter.WithLabelValues(instance.Name, tName, "patch-error").Inc()
+				// check for syntax error in policy
+				if k8serrors.IsInvalid(err) {
+					policyUserErrorsCounter.WithLabelValues(instance.Name, tName, "format-error").Inc()
+				} else {
+					policySystemErrorsCounter.WithLabelValues(instance.Name, tName, "patch-error").Inc()
+				}
 
 				continue
 			}

--- a/test/e2e/case21_syntax_error_metric_test.go
+++ b/test/e2e/case21_syntax_error_metric_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2020 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package e2e
+
+import (
+	"strconv"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	policyUtils "open-cluster-management.io/governance-policy-propagator/test/utils"
+
+	"open-cluster-management.io/governance-policy-framework-addon/test/utils"
+)
+
+var _ = Describe("Test proper metrics handling on syntax error", Ordered, func() {
+	userMetricName := "policy_user_errors_total"
+	policyName := "case21-policy"
+	errPolicyFile := "../resources/case21_syntax_error_metric/case21-test-policy-err.yaml"
+	correctPolicyFile := "../resources/case21_syntax_error_metric/case21-test-policy.yaml"
+
+	cleanup := func() {
+		By("Deleting a policy on hub cluster in ns:" + clusterNamespaceOnHub)
+		// Clean up and ignore any errors (in case it was deleted previously)
+		_, _ = kubectlHub("delete", "-f", errPolicyFile, "-n", clusterNamespaceOnHub)
+		opt := metav1.ListOptions{}
+		policyUtils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 0, true, defaultTimeoutSeconds)
+		policyUtils.ListWithTimeout(clientManagedDynamic, gvrPolicy, opt, 0, true, defaultTimeoutSeconds)
+	}
+
+	AfterAll(cleanup)
+
+	It("Should increment user error metric when applying new policy with syntax error", func() {
+		hubApplyPolicy(policyName, errPolicyFile)
+
+		By("Checking for the " + userMetricName + " metric on the template-sync controller")
+		values := []string{}
+		Eventually(func() []string {
+			values = utils.GetMetrics(userMetricName, policyName)
+
+			return values
+		}, defaultTimeoutSeconds, 1).Should(HaveLen(1))
+		Expect(strconv.Atoi(values[0])).To(BeNumerically(">=", 1))
+	})
+
+	It("Should clean up user error metric on policy deletion", func() {
+		By(
+			"Deleting policy " + policyName + " on hub cluster " +
+				"in ns:" + clusterNamespaceOnHub,
+		)
+		cleanup()
+		By("Checking for the " + userMetricName + " metric on the template-sync controller")
+		values := []string{}
+		Eventually(func() []string {
+			values = utils.GetMetrics(userMetricName, policyName)
+
+			return values
+		}, defaultTimeoutSeconds, 1).Should(HaveLen(0))
+	})
+
+	It("Should increment user error metric when patching a syntax error onto a correct policy", func() {
+		hubApplyPolicy(policyName, correctPolicyFile)
+		hubApplyPolicy(policyName, errPolicyFile)
+
+		By("Checking for the " + userMetricName + " metric on the template-sync controller")
+		values := []string{}
+		Eventually(func() []string {
+			values = utils.GetMetrics(userMetricName, policyName)
+
+			return values
+		}, defaultTimeoutSeconds, 1).Should(HaveLen(1))
+		Expect(strconv.Atoi(values[0])).To(BeNumerically(">=", 1))
+	})
+})

--- a/test/resources/case21_syntax_error_metric/case21-test-policy-err.yaml
+++ b/test/resources/case21_syntax_error_metric/case21-test-policy-err.yaml
@@ -1,0 +1,20 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: case21-policy
+  labels:
+    policy.open-cluster-management.io/cluster-name: managed
+    policy.open-cluster-management.io/cluster-namespace: managed
+    policy.open-cluster-management.io/root-policy: case21-policy
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: case21-configpolicy
+        spec:
+          remediationAction: inform
+          object-templates: false # syntax error

--- a/test/resources/case21_syntax_error_metric/case21-test-policy.yaml
+++ b/test/resources/case21_syntax_error_metric/case21-test-policy.yaml
@@ -1,0 +1,30 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: case21-policy
+  labels:
+    policy.open-cluster-management.io/cluster-name: managed
+    policy.open-cluster-management.io/cluster-namespace: managed
+    policy.open-cluster-management.io/root-policy: case21-policy
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: case21-configpolicy
+        spec:
+          remediationAction: inform
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Pod
+                metadata:
+                  name: nginx-pod-e2e
+                  namespace: default
+                spec:
+                  containers:
+                    - name: nginx


### PR DESCRIPTION
**Solution:** Added simple checks for syntax errors to determine whether to increment user or system error metrics
**Ref:** https://issues.redhat.com/browse/ACM-3160