### PR TITLE
[2.8 Manual Sync] Fix bug where user error validation was being ignored

### DIFF
--- a/controllers/templatesync/template_sync.go
+++ b/controllers/templatesync/template_sync.go
@@ -265,7 +265,7 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 			resultError = err
 			errMsg := fmt.Sprintf("Failed to decode policy template with err: %s", err)
 
-			_ = r.emitTemplateError(ctx, instance, tIndex, fmt.Sprintf("[template %v]", tIndex), false, errMsg)
+			_ = r.emitTemplateError(ctx, instance, tIndex, fmt.Sprintf("template-%v", tIndex), false, errMsg)
 
 			reqLogger.Error(resultError, "Failed to decode the policy template", "templateIndex", tIndex)
 
@@ -315,7 +315,7 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 				errMsg := fmt.Sprintf("Failed to decode policy template with err: %s", resultError)
 
 				_ = r.emitTemplateError(ctx, instance, tIndex,
-					fmt.Sprintf("[template %v]", tIndex), isClusterScoped, errMsg)
+					fmt.Sprintf("template-%v", tIndex), isClusterScoped, errMsg)
 
 				reqLogger.Error(resultError, "Failed to decode the policy template", "templateIndex", tIndex)
 
@@ -345,7 +345,7 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 			resultError = k8serrors.NewBadRequest(errMsg)
 
 			_ = r.emitTemplateError(ctx, instance, tIndex,
-				fmt.Sprintf("[template %v]", tIndex), isClusterScoped, errMsg)
+				fmt.Sprintf("template-%v", tIndex), isClusterScoped, errMsg)
 
 			reqLogger.Error(resultError, "Failed to process the policy template", "templateIndex", tIndex)
 

--- a/test/e2e/case22_user_validation_error_test.go
+++ b/test/e2e/case22_user_validation_error_test.go
@@ -1,0 +1,84 @@
+// Copyright (c) 2023 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"open-cluster-management.io/config-policy-controller/test/utils"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	policyUtils "open-cluster-management.io/governance-policy-propagator/test/utils"
+)
+
+var _ = Describe("Test proper metrics handling on syntax error", Ordered, func() {
+	case22ErrPolicyName := "case22-err"
+	case22ErrYaml := "../resources/case22_user_validation_error/case22-test-err.yaml"
+	case22CorrectPolicyName := "case22-correct"
+	case22CorrectYaml := "../resources/case22_user_validation_error/case22-test-correct.yaml"
+
+	cleanup := func() {
+		By("Deleting test policies on hub cluster in ns:" + clusterNamespaceOnHub)
+		// Clean up and ignore any errors (in case it was deleted previously)
+		_, _ = kubectlHub("delete", "-f", case22ErrYaml, "-n", clusterNamespaceOnHub, "--ignore-not-found")
+		_, _ = kubectlHub("delete", "-f", case22CorrectYaml, "-n", clusterNamespaceOnHub, "--ignore-not-found")
+		opt := metav1.ListOptions{}
+		policyUtils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 0, true, defaultTimeoutSeconds)
+		policyUtils.ListWithTimeout(clientManagedDynamic, gvrPolicy, opt, 0, true, defaultTimeoutSeconds)
+	}
+
+	AfterAll(cleanup)
+
+	It("Verifies NonCompliant status for non-decodable policy", func() {
+		hubApplyPolicy(case22ErrPolicyName, case22ErrYaml)
+
+		By("Waiting for " + case22ErrPolicyName + " to become NonCompliant")
+		Eventually(func() interface{} {
+			plc := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy,
+				case22ErrPolicyName, clusterNamespaceOnHub,
+				true, defaultTimeoutSeconds,
+			)
+
+			return utils.GetComplianceState(plc)
+		}, defaultTimeoutSeconds, 1).Should(Equal("NonCompliant"))
+	})
+
+	It("Verifies that validation errors are shown", func() {
+		By("Checking message on " + case22ErrPolicyName)
+		var plc *policiesv1.Policy
+		Eventually(func(g Gomega) interface{} {
+			managedPlc := utils.GetWithTimeout(
+				clientManagedDynamic,
+				gvrPolicy,
+				case22ErrPolicyName,
+				clusterNamespace,
+				true,
+				defaultTimeoutSeconds)
+			err := runtime.DefaultUnstructuredConverter.FromUnstructured(managedPlc.Object, &plc)
+			g.Expect(err).ToNot(HaveOccurred())
+			if len(plc.Status.Details) < 1 {
+				return ""
+			}
+
+			return plc.Status.Details[1].History[0].Message
+		}, defaultTimeoutSeconds, 1).Should(ContainSubstring("NonCompliant; template-error;"))
+	})
+
+	It("Verifies correct policy does not become NonCompliant", func() {
+		hubApplyPolicy(case22CorrectPolicyName, case22CorrectYaml)
+
+		By("Checking that " + case22CorrectPolicyName + " does not become NonCompliant")
+		Consistently(func() interface{} {
+			plc := utils.GetWithTimeout(
+				clientHubDynamic, gvrPolicy,
+				case22CorrectPolicyName, clusterNamespaceOnHub,
+				true, defaultTimeoutSeconds,
+			)
+
+			return utils.GetComplianceState(plc)
+		}, defaultTimeoutSeconds, 1).ShouldNot(Equal("NonCompliant"))
+	})
+})

--- a/test/resources/case22_user_validation_error/case22-test-correct.yaml
+++ b/test/resources/case22_user_validation_error/case22-test-correct.yaml
@@ -1,0 +1,47 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: case22-correct
+  labels:
+    policy.open-cluster-management.io/cluster-name: managed
+    policy.open-cluster-management.io/cluster-namespace: managed
+    policy.open-cluster-management.io/root-policy: case22-correct
+spec:
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: checkfailednodes
+        spec:
+          object-templates-raw: |
+            {{- range $node := (lookup "v1" "Node"  "" "").items }}
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Node
+                metadata:
+                  name: test-node
+                status:
+                  conditions:
+                  - message: kubelet has sufficient memory available
+                    reason: KubeletHasSufficientMemory
+                    status: "False"
+                    type: MemoryPressure
+                  - message: kubelet has no disk pressure
+                    reason: KubeletHasNoDiskPressure
+                    status: "False"
+                    type: DiskPressure
+                  - message: kubelet has sufficient PID available
+                    reason: KubeletHasSufficientPID
+                    status: "False"
+                    type: PIDPressure
+                  - message: kubelet is posting ready status
+                    reason: KubeletReady
+                    status: "True"
+                    type: Ready
+            {{- end }}
+          remediationAction: inform
+          severity: low
+  remediationAction: inform

--- a/test/resources/case22_user_validation_error/case22-test-err.yaml
+++ b/test/resources/case22_user_validation_error/case22-test-err.yaml
@@ -1,0 +1,51 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: case22-err
+  labels:
+    policy.open-cluster-management.io/cluster-name: managed
+    policy.open-cluster-management.io/cluster-namespace: managed
+    policy.open-cluster-management.io/root-policy: case22-err
+  creationTimestamp: 2023-08-07T09:21:13Z
+  generation: 4
+  managedFields:
+  resourceVersion: "168475"
+  uid: d40e4a53-919a-4d5e-a23e-de32eb9ae710
+spec:
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        spec:
+          apiVersion: policy.open-cluster-management.io/v1
+          kind: ConfigurationPolicy
+          metadata:
+            name: checkfailednodes
+          severity: low
+          spec:
+            object-templates-raw: |
+              {{- /* loop over nodes*/ -}}
+              {{- range $node := (lookup "v1" "Node"  "").items }}
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: v1
+                  kind: Node
+                  metadata:
+                    name: {{ $node }}
+                  status:
+                    conditions:
+                    - message: kubelet has sufficient memory available
+                      reason: KubeletHasSufficientMemory
+                      status: "False"
+                      type: MemoryPressure
+            remediationAction: inform
+            severity: high
+  remediationAction: inform
+status:
+  compliant: Compliant
+  placement:
+    - placement: testix-placement
+      placementBinding: testix-placement
+  status:
+    - clustername: local-cluster
+      clusternamespace: local-cluster
+      compliant: Compliant


### PR DESCRIPTION
Regex formatting changed for template sync to be read in policy status sync and policy template evaluation changed to evaluate erroneous policy templates

Signed-off-by: Jeffrey Luo <jeluo@redhat.com>
(cherry picked from commit 03bd852e4b4203506256317b4b9879fdbda5a105) (cherry picked from commit fcb4cd2bb6c7d24c275c09d21bf1d7f96ae69def)