### PR TITLE
Use SA for E2E

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -67,10 +67,15 @@ jobs:
       run: |
         make kind-bootstrap-cluster-dev
 
+    - name: Ensure Service Account kubeconfig
+      run: |
+        KUBECONFIG=${PWD}/kubeconfig_managed make kind-ensure-sa
+        KUBECONFIG=${PWD}/kubeconfig_hub make kind-ensure-sa
+
     - name: E2E Tests
       run: |
         export GOPATH=$(go env GOPATH)
-        make e2e-test-coverage
+        KUBECONFIG=${PWD}/kubeconfig_managed make e2e-test-coverage
 
     - name: E2E Tests That Simulate Hosted Mode
       run: |
@@ -79,17 +84,17 @@ jobs:
         export E2E_CLUSTER_NAMESPACE="other-namespace"
         export E2E_CLUSTER_NAMESPACE_ON_HUB="other-namespace-on-hub"
         export COVERAGE_E2E_OUT=coverage_e2e_hosted_mode.out
-        make e2e-test-coverage
+        KUBECONFIG=${PWD}/kubeconfig_managed make e2e-test-coverage
 
     - name: Verify Deployment Configuration
       run: |
         make build-images
-        make kind-deploy-controller-dev
+        KUBECONFIG=${PWD}/kubeconfig_managed_e2e make kind-deploy-controller-dev
 
     - name: Run E2E Uninstallation Tests
       if: ${{ matrix.kind == 'latest' }}
       run: |
-        make e2e-test-uninstall-coverage
+        KUBECONFIG=${PWD}/kubeconfig_managed make e2e-test-uninstall-coverage
 
     - name: Test Coverage and Report Generation
       if: ${{ matrix.kind == 'latest' }}

--- a/Makefile
+++ b/Makefile
@@ -38,13 +38,18 @@ endif
 
 # Handle KinD configuration
 KIND_NAME ?= test-managed
+KIND_HUB_NAME ?= test-hub
+KIND_CLUSTER_NAME ?= kind-$(KIND-NAME)
+KIND_HUB_CLUSTER_NAME ?= kind-$(KIND_HUB_NAME)
 KIND_NAMESPACE ?= open-cluster-management-agent-addon
 KIND_VERSION ?= latest
 MANAGED_CLUSTER_NAME ?= managed
+HUB_CLUSTER_NAME ?= hub
 HUB_CONFIG ?= $(PWD)/kubeconfig_hub
 HUB_CONFIG_INTERNAL ?= $(PWD)/kubeconfig_hub_internal
 MANAGED_CONFIG ?= $(PWD)/kubeconfig_managed
 deployOnHub ?= false
+CONTROLLER_NAME ?= $(shell cat COMPONENT_NAME 2> /dev/null)
 # Set the Kind version tag
 ifeq ($(KIND_VERSION), minimum)
 	KIND_ARGS = --image kindest/node:v1.19.16
@@ -62,7 +67,7 @@ export OSDK_FORCE_RUN_MODE ?= local
 
 # Image URL to use all building/pushing image targets;
 # Use your own docker registry and image name for dev/test by overridding the IMG and REGISTRY environment variable.
-IMG ?= $(shell cat COMPONENT_NAME 2> /dev/null)
+IMG ?= $(CONTROLLER_NAME)
 VERSION ?= $(shell cat COMPONENT_VERSION 2> /dev/null)
 REGISTRY ?= quay.io/stolostron
 TAG ?= latest
@@ -97,9 +102,7 @@ clean:
 	-rm build/_output/bin/*
 	-rm coverage*.out
 	-rm report*.json
-	-rm kubeconfig_managed
-	-rm kubeconfig_hub
-	-rm kubeconfig_hub_internal
+	-rm kubeconfig_*
 	-rm -r vendor/
 
 ############################################################
@@ -195,6 +198,11 @@ build-images:
 	@docker build -t ${IMAGE_NAME_AND_VERSION} -f build/Dockerfile .
 	@docker tag ${IMAGE_NAME_AND_VERSION} $(REGISTRY)/$(IMG):$(TAG)
 
+.PHONY: deploy
+deploy: generate-operator-yaml
+	kubectl apply -f deploy/operator.yaml -n $(KIND_NAMESPACE) --kubeconfig=$(MANAGED_CONFIG)_e2e
+	
+
 ############################################################
 # Generate manifests
 ############################################################
@@ -227,10 +235,10 @@ kustomize: ## Download kustomize locally if necessary.
 GINKGO = $(LOCAL_BIN)/ginkgo
 
 .PHONY: kind-bootstrap-cluster
-kind-bootstrap-cluster: kind-create-cluster install-crds kind-deploy-controller install-resources
+kind-bootstrap-cluster: kind-bootstrap-cluster-dev kind-deploy-controller
 
 .PHONY: kind-bootstrap-cluster-dev
-kind-bootstrap-cluster-dev: kind-create-cluster install-crds install-resources
+kind-bootstrap-cluster-dev: kind-create-all-clusters install-crds kind-controller-all-kubeconfigs
 
 
 HOSTED ?= none
@@ -244,21 +252,18 @@ kind-deploy-controller-dev:
 	fi
 
 .PHONY: kind-deploy-controller
-kind-deploy-controller:
-	@echo installing $(IMG)
-	-kubectl create ns $(KIND_NAMESPACE) --kubeconfig=$(MANAGED_CONFIG)
-	-kubectl create secret -n $(KIND_NAMESPACE) generic hub-kubeconfig --from-file=kubeconfig=$(HUB_CONFIG_INTERNAL) --kubeconfig=$(MANAGED_CONFIG)
-	kubectl apply -f deploy/operator.yaml -n $(KIND_NAMESPACE) --kubeconfig=$(MANAGED_CONFIG)
+kind-deploy-controller: generate-operator-yaml install-resources deploy
+	-kubectl create secret -n $(KIND_NAMESPACE) generic hub-kubeconfig --from-file=kubeconfig=$(HUB_CONFIG_INTERNAL) --kubeconfig=$(MANAGED_CONFIG)_e2e
 
 .PHONY: kind-deploy-controller-dev-normal
 kind-deploy-controller-dev-normal: kind-deploy-controller
 	@echo Pushing image to KinD cluster
 	kind load docker-image $(REGISTRY)/$(IMG):$(TAG) --name $(KIND_NAME)
 	@echo "Patch deployment image"
-	kubectl patch deployment $(IMG) -n $(KIND_NAMESPACE) -p "{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"$(IMG)\",\"args\":[\"--hub-cluster-configfile=/var/run/klusterlet/kubeconfig\", \"--cluster-namespace=$(MANAGED_CLUSTER_NAME)\", \"--enable-lease=true\", \"--log-level=2\", \"--disable-spec-sync=$(deployOnHub)\"]}]}}}}" --kubeconfig=$(MANAGED_CONFIG)
-	kubectl patch deployment $(IMG) -n $(KIND_NAMESPACE) -p "{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"$(IMG)\",\"imagePullPolicy\":\"Never\"}]}}}}" --kubeconfig=$(MANAGED_CONFIG)
-	kubectl patch deployment $(IMG) -n $(KIND_NAMESPACE) -p "{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"$(IMG)\",\"image\":\"$(REGISTRY)/$(IMG):$(TAG)\"}]}}}}" --kubeconfig=$(MANAGED_CONFIG)
-	kubectl rollout status -n $(KIND_NAMESPACE) deployment $(IMG) --timeout=180s --kubeconfig=$(MANAGED_CONFIG)
+	kubectl patch deployment $(IMG) -n $(KIND_NAMESPACE) -p "{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"$(IMG)\",\"args\":[\"--hub-cluster-configfile=/var/run/klusterlet/kubeconfig\", \"--cluster-namespace=$(MANAGED_CLUSTER_NAME)\", \"--enable-lease=true\", \"--log-level=2\", \"--disable-spec-sync=$(deployOnHub)\"]}]}}}}" --kubeconfig=$(MANAGED_CONFIG)_e2e
+	kubectl patch deployment $(IMG) -n $(KIND_NAMESPACE) -p "{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"$(IMG)\",\"imagePullPolicy\":\"Never\"}]}}}}" --kubeconfig=$(MANAGED_CONFIG)_e2e
+	kubectl patch deployment $(IMG) -n $(KIND_NAMESPACE) -p "{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"$(IMG)\",\"image\":\"$(REGISTRY)/$(IMG):$(TAG)\"}]}}}}" --kubeconfig=$(MANAGED_CONFIG)_e2e
+	kubectl rollout status -n $(KIND_NAMESPACE) deployment $(IMG) --timeout=180s --kubeconfig=$(MANAGED_CONFIG)_e2e
 
 .PHONY: kind-deploy-controller-dev-addon
 kind-deploy-controller-dev-addon:
@@ -267,38 +272,43 @@ kind-deploy-controller-dev-addon:
 	kubectl annotate -n $(subst -hosted,,$(KIND_NAMESPACE)) --overwrite managedclusteraddon governance-policy-framework\
 		addon.open-cluster-management.io/values='{"global":{"imagePullPolicy": "Never", "imageOverrides":{"governance_policy_framework_addon": "$(REGISTRY)/$(IMG):$(TAG)"}}}'
 
+.PHONY: kind-create-all-clusters
+kind-create-all-clusters:
+	CLUSTER_NAME=$(MANAGED_CLUSTER_NAME) $(MAKE) kind-create-cluster
+	CLUSTER_NAME=$(HUB_CLUSTER_NAME) KIND_NAME=$(KIND_HUB_NAME) KIND_CLUSTER_NAME=$(KIND_HUB_CLUSTER_NAME) $(MAKE) kind-create-cluster
 
-.PHONY: kind-create-cluster
-kind-create-cluster:
-	@echo "creating cluster"
-	kind create cluster --name test-hub $(KIND_ARGS)
-	kind get kubeconfig --name test-hub > $(HUB_CONFIG)
-	# needed for managed -> hub communication
-	kind get kubeconfig --name test-hub --internal > $(HUB_CONFIG_INTERNAL)
-	kind create cluster --name $(KIND_NAME) $(KIND_ARGS)
-	kind get kubeconfig --name $(KIND_NAME) > $(MANAGED_CONFIG)
+.PHONY: kind-controller-all-kubeconfigs
+kind-controller-all-kubeconfigs:
+	CLUSTER_NAME=$(MANAGED_CLUSTER_NAME) $(MAKE) kind-controller-kubeconfig
+	CLUSTER_NAME=$(HUB_CLUSTER_NAME) KIND_NAME=$(KIND_HUB_NAME) KIND_CLUSTER_NAME=$(KIND_HUB_CLUSTER_NAME) $(MAKE) kind-controller-kubeconfig
+	yq e '.clusters[0].cluster.server = "https://$(KIND_HUB_NAME)-control-plane:6443"' $(HUB_CONFIG) > $(HUB_CONFIG_INTERNAL)
 
 .PHONY: kind-delete-cluster
 kind-delete-cluster:
-	kind delete cluster --name test-hub
+	kind delete cluster --name $(KIND_HUB_NAME)
 	kind delete cluster --name $(KIND_NAME)
 
 .PHONY: install-crds
 install-crds:
 	@echo installing crds
-	kubectl apply -f https://raw.githubusercontent.com/stolostron/governance-policy-propagator/$(BRANCH)/deploy/crds/policy.open-cluster-management.io_policies.yaml --kubeconfig=$(HUB_CONFIG)
-	kubectl apply -f https://raw.githubusercontent.com/stolostron/governance-policy-propagator/$(BRANCH)/deploy/crds/policy.open-cluster-management.io_policies.yaml --kubeconfig=$(MANAGED_CONFIG)
-	kubectl apply -f https://raw.githubusercontent.com/stolostron/config-policy-controller/$(BRANCH)/deploy/crds/policy.open-cluster-management.io_configurationpolicies.yaml --kubeconfig=$(MANAGED_CONFIG)
+	kubectl apply -f https://raw.githubusercontent.com/stolostron/governance-policy-propagator/$(BRANCH)/deploy/crds/policy.open-cluster-management.io_policies.yaml --kubeconfig=$(HUB_CONFIG)_e2e
+	kubectl apply -f https://raw.githubusercontent.com/stolostron/governance-policy-propagator/$(BRANCH)/deploy/crds/policy.open-cluster-management.io_policies.yaml --kubeconfig=$(MANAGED_CONFIG)_e2e
+	kubectl apply -f https://raw.githubusercontent.com/stolostron/config-policy-controller/$(BRANCH)/deploy/crds/policy.open-cluster-management.io_configurationpolicies.yaml --kubeconfig=$(MANAGED_CONFIG)_e2e
 
 .PHONY: install-resources
 install-resources:
 	@echo creating namespace on hub
-	-kubectl create ns $(MANAGED_CLUSTER_NAME) --kubeconfig=$(HUB_CONFIG)
+	-kubectl create ns $(MANAGED_CLUSTER_NAME) --kubeconfig=$(HUB_CONFIG)_e2e
 	@echo creating namespace on managed
-	-kubectl create ns $(MANAGED_CLUSTER_NAME) --kubeconfig=$(MANAGED_CONFIG)
+	-kubectl create ns $(MANAGED_CLUSTER_NAME) --kubeconfig=$(MANAGED_CONFIG)_e2e
+	@echo Deploying roles and service account
+	-kubectl create ns $(KIND_NAMESPACE) --kubeconfig=$(MANAGED_CONFIG)_e2e
+	-kubectl apply -k deploy/rbac --kubeconfig=$(MANAGED_CONFIG)_e2e
+	-kubectl create ns $(KIND_NAMESPACE) --kubeconfig=$(HUB_CONFIG)_e2e
+	-kubectl apply -k deploy/hubpermissions --kubeconfig=$(HUB_CONFIG)_e2e
 	@if [ "$(KIND_VERSION)" != "minimum" ]; then \
 		echo installing Gatekeeper on the managed cluster; \
-		kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper/v3.11.0/deploy/gatekeeper.yaml  --kubeconfig=$(MANAGED_CONFIG); \
+		kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper/v3.11.0/deploy/gatekeeper.yaml  --kubeconfig=$(MANAGED_CONFIG)_e2e; \
 	fi
 
 .PHONY: e2e-dependencies
@@ -329,7 +339,7 @@ e2e-test-uninstall-coverage: e2e-run-instrumented scale-down-deployment e2e-test
 
 .PHONY: scale-down-deployment
 scale-down-deployment:
-	kubectl scale deployment $(IMG) -n $(KIND_NAMESPACE) --replicas=0 --kubeconfig=$(MANAGED_CONFIG)
+	kubectl scale deployment $(IMG) -n $(KIND_NAMESPACE) --replicas=0 --kubeconfig=$(MANAGED_CONFIG)_e2e
 
 .PHONY: e2e-build-instrumented
 e2e-build-instrumented:

--- a/build/common/Makefile.common.mk
+++ b/build/common/Makefile.common.mk
@@ -140,7 +140,7 @@ kind-ensure-sa:
 
 .PHONY: kind-controller-kubeconfig
 kind-controller-kubeconfig: install-resources
-	kubectl -n $(CONTROLLER_NAMESPACE) apply -f test/resources/e2e_controller_secret.yaml
+	kubectl -n $(CONTROLLER_NAMESPACE) apply -f test/resources/e2e_controller_secret.yaml --kubeconfig=$(PWD)/kubeconfig_$(CLUSTER_NAME)_e2e
 	-rm kubeconfig_$(CLUSTER_NAME)
 	@kubectl config set-cluster $(KIND_CLUSTER_NAME) --kubeconfig=$(PWD)/kubeconfig_$(CLUSTER_NAME) \
 		--server=$(shell kubectl config view --minify -o jsonpath='{.clusters[].cluster.server}' --kubeconfig=kubeconfig_$(CLUSTER_NAME)_e2e) \

--- a/controllers/secretsync/secret_sync.go
+++ b/controllers/secretsync/secret_sync.go
@@ -53,7 +53,7 @@ type SecretReconciler struct {
 
 // WARNING: In production, this should be namespaced to the actual managed cluster namespace.
 //+kubebuilder:rbac:groups=core,resources=secrets,verbs=create
-//+kubebuilder:rbac:groups=core,resources=secrets,resourceNames=policy-encryption-key,verbs=delete;get;update;list
+//+kubebuilder:rbac:groups=core,resources=secrets,resourceNames=policy-encryption-key,verbs=delete;get;update;list;watch
 
 // Reconcile handles updates to the "policy-encryption-key" Secret in the managed cluster namespace on the Hub.
 // The method is responsible for synchronizing the Secret to the managed cluster namespace on the managed cluster.

--- a/controllers/uninstall/triggeruninstall.go
+++ b/controllers/uninstall/triggeruninstall.go
@@ -32,6 +32,8 @@ var triggerLog = ctrl.Log.WithName("trigger-uninstall")
 
 const AnnotationKey = "policy.open-cluster-management.io/uninstalling"
 
+//+kubebuilder:rbac:groups=policy.open-cluster-management.io,resources=policies,verbs=deletecollection;
+
 // Trigger adds the uninstallation annotation to the Deployment, then deletes all the policies.
 // It will return nil only when all the policies are gone.
 // It takes command line arguments to configure itself.

--- a/deploy/hubpermissions/kustomization.yaml
+++ b/deploy/hubpermissions/kustomization.yaml
@@ -1,0 +1,4 @@
+namespace: open-cluster-management-agent-addon
+
+resources:
+  - ../rbac

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -113,6 +113,7 @@ rules:
   - get
   - list
   - update
+  - watch
 - apiGroups:
   - policy.open-cluster-management.io
   resources:
@@ -132,6 +133,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch

--- a/deploy/rbac/role.yaml
+++ b/deploy/rbac/role.yaml
@@ -83,6 +83,7 @@ rules:
   - get
   - list
   - update
+  - watch
 - apiGroups:
   - policy.open-cluster-management.io
   resources:
@@ -102,6 +103,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch

--- a/deploy/rbac/service_account.yaml
+++ b/deploy/rbac/service_account.yaml
@@ -2,3 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: governance-policy-framework-addon
+  namespace: open-cluster-management-agent-addon

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -72,11 +72,11 @@ func init() {
 	ctrl.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 	flag.StringVar(
 		&kubeconfigHub,
-		"kubeconfig_hub", "../../kubeconfig_hub",
+		"kubeconfig_hub", "../../kubeconfig_hub_e2e",
 		"Location of the kubeconfig to use; defaults to KUBECONFIG if not set")
 	flag.StringVar(
 		&kubeconfigManaged,
-		"kubeconfig_managed", "../../kubeconfig_managed",
+		"kubeconfig_managed", "../../kubeconfig_managed_e2e",
 		"Location of the kubeconfig to use; defaults to KUBECONFIG if not set")
 }
 
@@ -245,13 +245,13 @@ func LoadConfig(url, kubeconfig, context string) (*rest.Config, error) {
 }
 
 func kubectlHub(args ...string) (string, error) {
-	args = append(args, "--kubeconfig=../../kubeconfig_hub")
+	args = append(args, "--kubeconfig=../../kubeconfig_hub_e2e")
 
 	return propagatorutils.KubectlWithOutput(args...)
 }
 
 func kubectlManaged(args ...string) (string, error) {
-	args = append(args, "--kubeconfig=../../kubeconfig_managed")
+	args = append(args, "--kubeconfig=../../kubeconfig_managed_e2e")
 
 	return propagatorutils.KubectlWithOutput(args...)
 }

--- a/test/resources/e2e_controller_secret.yaml
+++ b/test/resources/e2e_controller_secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/service-account-token
+metadata:
+  name: governance-policy-framework-addon
+  annotations:
+    kubernetes.io/service-account.name: governance-policy-framework-addon


### PR DESCRIPTION
Changes:
- Create service accounts and related resources on both the hub and managed cluster
- Create separate kubeconfig files to be used for the controller and E2E tests
- Utilize the common makefile when bootstrapping clusters

ref: https://issues.redhat.com/browse/ACM-3301
Signed-off-by: Jason Zhang <jaszhang@redhat.com>
(cherry picked from commit 80c476a4fa8c35b765b17dc936ba05e9f5002e57)
closes: https://github.com/stolostron/governance-policy-framework-addon/issues/237