### PR TITLE
Bump the github-actions group with 2 updates

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -33,13 +33,13 @@ jobs:
     name: KinD tests
     steps:
     - name: Checkout Governance Policy Framework Addon
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         path: governance-policy-framework-addon
         fetch-depth: 0 # Fetch all history for all tags and branches
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
         go-version-file: governance-policy-framework-addon/go.mod
 


### PR DESCRIPTION
Bumps the github-actions group with 2 updates: [actions/checkout](https://github.com/actions/checkout) and [actions/setup-go](https://github.com/actions/setup-go).

Updates `actions/checkout` from 3 to 4
- [Release notes](https://github.com/actions/checkout/releases)
- [Changelog](https://github.com/actions/checkout/blob/main/CHANGELOG.md)
- [Commits](https://github.com/actions/checkout/compare/v3...v4)

Updates `actions/setup-go` from 3 to 5
- [Release notes](https://github.com/actions/setup-go/releases)
- [Commits](https://github.com/actions/setup-go/compare/v3...v5)

---
updated-dependencies:
- dependency-name: actions/checkout dependency-type: direct:production update-type: version-update:semver-major dependency-group: github-actions
- dependency-name: actions/setup-go dependency-type: direct:production update-type: version-update:semver-major dependency-group: github-actions ...

Signed-off-by: dependabot[bot] <support@github.com>
(cherry picked from commit 1b5ccdcb14ea14477c9b8a8f6b960f59acb9e1c9)

Closes #260 