### PR TITLE
Fix template sync set to Nomcompliant when context cancel

### DIFF
--- a/config/test/crd/configuration.yaml
+++ b/config/test/crd/configuration.yaml
@@ -1,0 +1,342 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    policy.open-cluster-management.io/policy-type: template
+  name: configurationpolicies.policy.open-cluster-management.io
+spec:
+  group: policy.open-cluster-management.io
+  names:
+    kind: ConfigurationPolicy
+    listKind: ConfigurationPolicyList
+    plural: configurationpolicies
+    singular: configurationpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.compliant
+      name: Compliance state
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: ConfigurationPolicy is the Schema for the configurationpolicies
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ConfigurationPolicySpec defines the desired state of ConfigurationPolicy
+            oneOf:
+            - required:
+              - object-templates
+            - required:
+              - object-templates-raw
+            properties:
+              evaluationInterval:
+                description: |-
+                  Configures the minimum elapsed time before a ConfigurationPolicy is reevaluated. If the policy
+                  spec is changed, or if the list of namespaces selected by the policy changes, the policy may be
+                  evaluated regardless of the settings here.
+                properties:
+                  compliant:
+                    description: |-
+                      The minimum elapsed time before a ConfigurationPolicy is reevaluated when in the compliant state. Set this to
+                      "never" to disable reevaluation when in the compliant state.
+                    pattern: ^(?:(?:(?:[0-9]+(?:.[0-9])?)(?:h|m|s|(?:ms)|(?:us)|(?:ns)))|never)+$
+                    type: string
+                  noncompliant:
+                    description: |-
+                      The minimum elapsed time before a ConfigurationPolicy is reevaluated when in the noncompliant state. Set this to
+                      "never" to disable reevaluation when in the noncompliant state.
+                    pattern: ^(?:(?:(?:[0-9]+(?:.[0-9])?)(?:h|m|s|(?:ms)|(?:us)|(?:ns)))|never)+$
+                    type: string
+                type: object
+              namespaceSelector:
+                description: |-
+                  'namespaceSelector' defines the list of namespaces to include/exclude for objects defined in
+                  spec.objectTemplates. All selector rules are ANDed. If 'include' is not provided but
+                  'matchLabels' and/or 'matchExpressions' are, 'include' will behave as if ['*'] were given. If
+                  'matchExpressions' and 'matchLabels' are both not provided, 'include' must be provided to
+                  retrieve namespaces.
+                properties:
+                  exclude:
+                    description: '''exclude'' is an array of filepath expressions
+                      to exclude objects by name.'
+                    items:
+                      minLength: 1
+                      type: string
+                    type: array
+                  include:
+                    description: '''include'' is an array of filepath expressions
+                      to include objects by name.'
+                    items:
+                      minLength: 1
+                      type: string
+                    type: array
+                  matchExpressions:
+                    description: '''matchExpressions'' is an array of label selector
+                      requirements matching objects by label.'
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: '''matchLabels'' is a map of {key,value} pairs matching
+                      objects by label.'
+                    type: object
+                type: object
+              object-templates:
+                description: |-
+                  'object-templates' and 'object-templates-raw' are arrays of objects for the configuration
+                  policy to check, create, modify, or delete on the cluster. 'object-templates' is an array
+                  of objects, while 'object-templates-raw' is a string containing an array of objects in
+                  YAML format. Only one of the two object-templates variables can be set in a given
+                  configurationPolicy.
+                items:
+                  description: ObjectTemplate describes how an object should look
+                  properties:
+                    complianceType:
+                      description: 'ComplianceType specifies whether it is: musthave,
+                        mustnothave, mustonlyhave'
+                      enum:
+                      - MustHave
+                      - Musthave
+                      - musthave
+                      - MustOnlyHave
+                      - Mustonlyhave
+                      - mustonlyhave
+                      - MustNotHave
+                      - Mustnothave
+                      - mustnothave
+                      type: string
+                    metadataComplianceType:
+                      description: MetadataComplianceType describes how to check compliance
+                        for the labels/annotations of a given object
+                      enum:
+                      - MustHave
+                      - Musthave
+                      - musthave
+                      - MustOnlyHave
+                      - Mustonlyhave
+                      - mustonlyhave
+                      type: string
+                    objectDefinition:
+                      description: ObjectDefinition defines required fields for the
+                        object
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    recordDiff:
+                      description: |-
+                        RecordDiff specifies whether (and where) to log the diff between the object on the
+                        cluster and the objectDefinition in the policy. Defaults to "None".
+                      enum:
+                      - Log
+                      - None
+                      type: string
+                  required:
+                  - complianceType
+                  - objectDefinition
+                  type: object
+                type: array
+              object-templates-raw:
+                description: |-
+                  'object-templates' and 'object-templates-raw' are arrays of objects for the configuration
+                  policy to check, create, modify, or delete on the cluster. 'object-templates' is an array
+                  of objects, while 'object-templates-raw' is a string containing an array of objects in
+                  YAML format. Only one of the two object-templates variables can be set in a given
+                  configurationPolicy.
+                type: string
+              pruneObjectBehavior:
+                default: None
+                description: |-
+                  PruneObjectBehavior is used to remove objects that are managed by the
+                  policy upon policy deletion.
+                enum:
+                - DeleteAll
+                - DeleteIfCreated
+                - None
+                type: string
+              remediationAction:
+                description: 'RemediationAction : enforce or inform'
+                enum:
+                - Inform
+                - inform
+                - Enforce
+                - enforce
+                type: string
+              severity:
+                description: 'Severity : low, medium, high, or critical'
+                enum:
+                - low
+                - Low
+                - medium
+                - Medium
+                - high
+                - High
+                - critical
+                - Critical
+                type: string
+            required:
+            - remediationAction
+            type: object
+          status:
+            description: ConfigurationPolicyStatus defines the observed state of ConfigurationPolicy
+            properties:
+              compliancyDetails:
+                items:
+                  description: TemplateStatus hold the status result
+                  properties:
+                    Compliant:
+                      description: ComplianceState shows the state of enforcement
+                      type: string
+                    Validity:
+                      description: Validity describes if it is valid or not
+                      properties:
+                        reason:
+                          type: string
+                        valid:
+                          type: boolean
+                      type: object
+                    conditions:
+                      items:
+                        description: Condition is the base struct for representing
+                          resource conditions
+                        properties:
+                          lastTransitionTime:
+                            description: The last time the condition transitioned
+                              from one status to another.
+                            format: date-time
+                            type: string
+                          message:
+                            description: A human readable message indicating details
+                              about the transition.
+                            type: string
+                          reason:
+                            description: The reason for the condition's last transition.
+                            type: string
+                          status:
+                            description: Status of the condition, one of True, False,
+                              Unknown.
+                            type: string
+                          type:
+                            description: Type of condition, e.g Complete or Failed.
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      type: array
+                  type: object
+                type: array
+              compliant:
+                description: ComplianceState shows the state of enforcement
+                type: string
+              lastEvaluated:
+                description: An ISO-8601 timestamp of the last time the policy was
+                  evaluated
+                type: string
+              lastEvaluatedGeneration:
+                description: The generation of the ConfigurationPolicy object when
+                  it was last evaluated
+                format: int64
+                type: integer
+              relatedObjects:
+                description: List of resources processed by the policy
+                items:
+                  description: RelatedObject is the list of objects matched by this
+                    Policy resource.
+                  properties:
+                    compliant:
+                      type: string
+                    object:
+                      description: ObjectResource is an object identified by the policy
+                        as a resource that needs to be validated.
+                      properties:
+                        apiVersion:
+                          description: API version of the referent.
+                          type: string
+                        kind:
+                          description: |-
+                            Kind of the referent. More info:
+                            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                          type: string
+                        metadata:
+                          description: Metadata values from the referent.
+                          properties:
+                            name:
+                              description: |-
+                                Name of the referent. More info:
+                                https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            namespace:
+                              description: |-
+                                Namespace of the referent. More info:
+                                https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                              type: string
+                          type: object
+                      type: object
+                    properties:
+                      properties:
+                        createdByPolicy:
+                          description: Whether the object was created by the parent
+                            policy
+                          type: boolean
+                        uid:
+                          description: Store object UID to help track object ownership
+                            for deletion
+                          type: string
+                      type: object
+                    reason:
+                      type: string
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/test/crd/policy.yaml
+++ b/config/test/crd/policy.yaml
@@ -1,0 +1,290 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: policies.policy.open-cluster-management.io
+spec:
+  group: policy.open-cluster-management.io
+  names:
+    kind: Policy
+    listKind: PolicyList
+    plural: policies
+    shortNames:
+    - plc
+    singular: policy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.remediationAction
+      name: Remediation action
+      type: string
+    - jsonPath: .status.compliant
+      name: Compliance state
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: Policy is the Schema for the policies API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PolicySpec defines the desired state of Policy
+            properties:
+              copyPolicyMetadata:
+                description: |-
+                  If set to true (default), all the policy's labels and annotations will be copied to the replicated policy.
+                  If set to false, only the policy framework specific policy labels and annotations will be copied to the
+                  replicated policy.
+                type: boolean
+              dependencies:
+                description: PolicyDependencies that apply to each template in this
+                  Policy
+                items:
+                  description: |-
+                    Each PolicyDependency defines an object reference which must be in a certain compliance
+                    state before the policy should be created.
+                  oneOf:
+                  - properties:
+                      kind:
+                        enum:
+                        - CertificatePolicy
+                        - ConfigurationPolicy
+                        - IamPolicy
+                      namespace:
+                        maxLength: 0
+                  - not:
+                      properties:
+                        kind:
+                          pattern: ^(?:(?:Certificate|Configuration|Iam)Policy)$
+                  properties:
+                    apiVersion:
+                      description: |-
+                        APIVersion defines the versioned schema of this representation of an object.
+                        Servers should convert recognized schemas to the latest internal value, and
+                        may reject unrecognized values.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                      type: string
+                    compliance:
+                      description: The ComplianceState (at path .status.compliant)
+                        required before the policy should be created
+                      enum:
+                      - Compliant
+                      - Pending
+                      - NonCompliant
+                      type: string
+                    kind:
+                      description: |-
+                        Kind is a string value representing the REST resource this object represents.
+                        Servers may infer this from the endpoint the client submits requests to.
+                        Cannot be updated.
+                        In CamelCase.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                      type: string
+                    name:
+                      description: The name of the object to be checked
+                      type: string
+                    namespace:
+                      description: The namespace of the object to be checked (optional)
+                      type: string
+                  required:
+                  - compliance
+                  - name
+                  type: object
+                type: array
+              disabled:
+                description: This provides the ability to enable and disable your
+                  policies.
+                type: boolean
+              policy-templates:
+                description: Used to create one or more policies to apply to a managed
+                  cluster
+                items:
+                  description: PolicyTemplate template for custom security policy
+                  properties:
+                    extraDependencies:
+                      description: Additional PolicyDependencies that only apply to
+                        this template
+                      items:
+                        description: |-
+                          Each PolicyDependency defines an object reference which must be in a certain compliance
+                          state before the policy should be created.
+                        oneOf:
+                        - properties:
+                            kind:
+                              enum:
+                              - CertificatePolicy
+                              - ConfigurationPolicy
+                              - IamPolicy
+                            namespace:
+                              maxLength: 0
+                        - not:
+                            properties:
+                              kind:
+                                pattern: ^(?:(?:Certificate|Configuration|Iam)Policy)$
+                        properties:
+                          apiVersion:
+                            description: |-
+                              APIVersion defines the versioned schema of this representation of an object.
+                              Servers should convert recognized schemas to the latest internal value, and
+                              may reject unrecognized values.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                            type: string
+                          compliance:
+                            description: The ComplianceState (at path .status.compliant)
+                              required before the policy should be created
+                            enum:
+                            - Compliant
+                            - Pending
+                            - NonCompliant
+                            type: string
+                          kind:
+                            description: |-
+                              Kind is a string value representing the REST resource this object represents.
+                              Servers may infer this from the endpoint the client submits requests to.
+                              Cannot be updated.
+                              In CamelCase.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          name:
+                            description: The name of the object to be checked
+                            type: string
+                          namespace:
+                            description: The namespace of the object to be checked
+                              (optional)
+                            type: string
+                        required:
+                        - compliance
+                        - name
+                        type: object
+                      type: array
+                    ignorePending:
+                      description: Ignore this template's Pending status when calculating
+                        the overall Policy status
+                      type: boolean
+                    objectDefinition:
+                      description: A Kubernetes object defining the policy to apply
+                        to a managed cluster
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                  required:
+                  - objectDefinition
+                  type: object
+                type: array
+              remediationAction:
+                description: This value (Enforce or Inform) will override the remediationAction
+                  on each template
+                enum:
+                - Inform
+                - inform
+                - Enforce
+                - enforce
+                type: string
+            required:
+            - disabled
+            - policy-templates
+            type: object
+          status:
+            description: PolicyStatus defines the observed state of Policy
+            properties:
+              compliant:
+                description: ComplianceState shows the state of enforcement
+                enum:
+                - Compliant
+                - Pending
+                - NonCompliant
+                type: string
+              details:
+                items:
+                  description: DetailsPerTemplate defines compliance details and history
+                  properties:
+                    compliant:
+                      description: ComplianceState shows the state of enforcement
+                      type: string
+                    history:
+                      items:
+                        description: ComplianceHistory defines compliance details
+                          history
+                        properties:
+                          eventName:
+                            type: string
+                          lastTimestamp:
+                            format: date-time
+                            type: string
+                          message:
+                            type: string
+                        type: object
+                      type: array
+                    templateMeta:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                  type: object
+                type: array
+              placement:
+                items:
+                  description: Placement defines the placement results
+                  properties:
+                    decisions:
+                      items:
+                        description: PlacementDecision defines the decision made by
+                          controller
+                        properties:
+                          clusterName:
+                            type: string
+                          clusterNamespace:
+                            type: string
+                        type: object
+                      type: array
+                    placement:
+                      type: string
+                    placementBinding:
+                      type: string
+                    placementRule:
+                      type: string
+                    policySet:
+                      type: string
+                  type: object
+                type: array
+              status:
+                items:
+                  description: CompliancePerClusterStatus defines compliance per cluster
+                    status
+                  properties:
+                    clustername:
+                      type: string
+                    clusternamespace:
+                      type: string
+                    compliant:
+                      description: ComplianceState shows the state of enforcement
+                      type: string
+                  type: object
+                type: array
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/controllers/templatesync/template_sync.go
+++ b/controllers/templatesync/template_sync.go
@@ -641,6 +641,11 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 
 			// a different error getting template object from cluster
 			resultError = err
+
+			if errors.Is(err, context.Canceled) {
+				return reconcile.Result{}, fmt.Errorf("failed to get the object in the policy template: %w", err)
+			}
+
 			errMsg := fmt.Sprintf("Failed to get the object in the policy template: %s", err)
 
 			_ = r.emitTemplateError(ctx, instance, tIndex, tName, isClusterScoped, errMsg)

--- a/controllers/templatesync/template_sync_test.go
+++ b/controllers/templatesync/template_sync_test.go
@@ -4,17 +4,27 @@ package templatesync
 
 import (
 	"context"
+	"errors"
+	"path/filepath"
 	"testing"
+	"time"
 
 	gktemplatesv1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1"
+	corev1 "k8s.io/api/core/v1"
+	extensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/record"
 	configpoliciesv1 "open-cluster-management.io/config-policy-controller/api/v1"
 	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	client "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 func TestHandleSyncSuccessNoDoubleRemoveStatus(t *testing.T) {
@@ -211,5 +221,145 @@ func TestHasDuplicateNames(t *testing.T) {
 	has = hasDupName(&policy)
 	if !has { // expect duplicate detection to return true
 		t.Fatal("Duplicate name not detected")
+	}
+}
+
+func TestContextCancel(t *testing.T) {
+	configPolicy := configpoliciesv1.ConfigurationPolicy{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ConfigurationPolicy",
+			APIVersion: "policy.open-cluster-management.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-configpolicy",
+			Namespace: "managed",
+		},
+		Status: configpoliciesv1.ConfigurationPolicyStatus{
+			ComplianceState: "",
+		},
+	}
+
+	outBytes, err := runtime.Encode(unstructured.UnstructuredJSONScheme, &configPolicy)
+	if err != nil {
+		t.Fatalf("Failed to encode ConfigurationPolicy: %s", err)
+	}
+
+	policy := &policiesv1.Policy{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Policy",
+			APIVersion: "policy.open-cluster-management.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-policy",
+			Namespace: "managed",
+		},
+		Spec: policiesv1.PolicySpec{
+			PolicyTemplates: []*policiesv1.PolicyTemplate{
+				{ObjectDefinition: runtime.RawExtension{Raw: outBytes}},
+			},
+		},
+		Status: policiesv1.PolicyStatus{
+			Details: []*policiesv1.DetailsPerTemplate{
+				{
+					ComplianceState: "NonCompliant",
+					History: []policiesv1.ComplianceHistory{
+						{
+							Message: "template-error; some error",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "managed"}}
+
+	scheme := runtime.NewScheme()
+
+	err = corev1.AddToScheme(scheme)
+	if err != nil {
+		t.Fatalf("Failed to set up the scheme: %s", err)
+	}
+
+	err = policiesv1.AddToScheme(scheme)
+	if err != nil {
+		t.Fatalf("Failed to set up the scheme: %s", err)
+	}
+
+	err = extensionsv1.AddToScheme(scheme)
+	if err != nil {
+		t.Fatalf("Failed to set up the scheme: %s", err)
+	}
+
+	err = configpoliciesv1.AddToScheme(scheme)
+	if err != nil {
+		t.Fatalf("Failed to set up the scheme: %s", err)
+	}
+
+	recorder := record.NewFakeRecorder(10)
+
+	testEnv := &envtest.Environment{
+		CRDDirectoryPaths: []string{filepath.Join("..", "..", "config", "test", "crd")},
+		Scheme:            scheme,
+	}
+	defer func() {
+		_ = testEnv.Stop()
+	}()
+
+	config, err := testEnv.Start()
+	if err != nil {
+		t.Fatalf("Failed to start testEnv")
+	}
+
+	fakeClient, err := client.New(config, client.Options{Scheme: scheme})
+	if err != nil {
+		t.Fatalf("Failed to create the Client")
+	}
+
+	err = fakeClient.Create(context.TODO(), ns)
+	if err != nil {
+		t.Fatalf("Failed to create the Namespace")
+	}
+
+	err = fakeClient.Create(context.TODO(), policy)
+	if err != nil {
+		t.Fatalf("Failed to convert the Policy")
+	}
+
+	err = fakeClient.Create(context.TODO(), &configPolicy)
+	if err != nil {
+		t.Fatalf("Failed to convert the ConfigPolicy")
+	}
+
+	fakeClientset := kubernetes.NewForConfigOrDie(config)
+
+	reconciler := PolicyReconciler{
+		Recorder:  recorder,
+		Client:    fakeClient,
+		Clientset: fakeClientset,
+		Config:    config,
+	}
+
+	// Sleep time
+	tests := []time.Duration{200, 100, 50, 10, time.Nanosecond * 10}
+
+	for _, sleepTime := range tests {
+		ctx, cancelFunc := context.WithCancel(context.Background())
+
+		go func() {
+			time.Sleep(sleepTime)
+			cancelFunc()
+		}()
+
+		input := reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-policy", Namespace: "managed"}}
+
+		_, err = reconciler.Reconcile(ctx, input)
+		if !errors.Is(err, context.Canceled) {
+			t.Fatal("Should be the context canceled error")
+		}
+
+		if len(recorder.Events) != 0 {
+			t.Fatal("Should not emit the canceled error")
+		}
 	}
 }


### PR DESCRIPTION
Actual: If the template-sync is shutting down and it's in the middle of a reconcile request, it can set the policy to noncompliant with this
Expect: If the error is that the context is cancelled, then the template sync should retry the reconcile rather than set the policy to noncompliant.
Ref: https://issues.redhat.com/browse/ACM-10402