### PR TITLE
Fix template sync set to Nomcompliant when context cancel

### DIFF
--- a/controllers/templatesync/template_sync.go
+++ b/controllers/templatesync/template_sync.go
@@ -641,6 +641,11 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 
 			// a different error getting template object from cluster
 			resultError = err
+
+			if errors.Is(err, context.Canceled) {
+				return reconcile.Result{}, fmt.Errorf("failed to get the object in the policy template: %w", err)
+			}
+
 			errMsg := fmt.Sprintf("Failed to get the object in the policy template: %s", err)
 
 			_ = r.emitTemplateError(ctx, instance, tIndex, tName, isClusterScoped, errMsg)


### PR DESCRIPTION
Bug: If the template-sync is shutting down and it's in the middle of a reconcile request, it can set the policy to noncompliant with this
Ref: https://issues.redhat.com/browse/ACM-10402