### PR TITLE
Send a non-support message for Iam

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -49,7 +49,9 @@
             "program": "${workspaceFolder}/test/e2e/e2e_suite_test.go",
             "args": [
                 "-ginkgo.debug",
-                "-ginkgo.v"
+                "-ginkgo.v",
+                "--kubeconfig_managed=${workspaceFolder}/kubeconfig_managed_e2e",
+                "--kubeconfig_hub=${workspaceFolder}/kubeconfig_hub_e2e",
             ],
             "env": {
                 "KUBECONFIG": "${workspaceFolder}/kubeconfig_managed_e2e"

--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ build:
 
 .PHONY: run
 run:
-	HUB_CONFIG=$(HUB_CONFIG) MANAGED_CONFIG=$(MANAGED_CONFIG) go run ./main.go --leader-elect=false --cluster-namespace=$(MANAGED_CLUSTER_NAME)
+	HUB_CONFIG=$(HUB_CONFIG) MANAGED_CONFIG=$(MANAGED_CONFIG) OSDK_FORCE_RUN_MODE="local" go run ./main.go --leader-elect=false --cluster-namespace=$(MANAGED_CLUSTER_NAME) --cluster-namespace-on-hub=$(MANAGED_CLUSTER_NAME) --log-level=3 --compliance-api-url=http://127.0.0.1:8385 
 
 ############################################################
 # images section

--- a/controllers/templatesync/template_sync.go
+++ b/controllers/templatesync/template_sync.go
@@ -300,6 +300,15 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 			continue
 		}
 
+		if strings.HasPrefix(object.GetObjectKind().GroupVersionKind().Kind, "Iam") {
+			errMsg := "IamPolicy is no longer supported"
+
+			_ = r.emitTemplateError(ctx, instance, tIndex, fmt.Sprintf("template-%v", tIndex), false, errMsg)
+
+			reqLogger.Error(resultError, errMsg, "templateIndex", tIndex)
+
+			continue
+		}
 		// Special handling booleans, whether this template is:
 		// - ContraintTemplate handled by Gatekeeper
 		// - Cluster scoped

--- a/test/e2e/case9_template_sync_test.go
+++ b/test/e2e/case9_template_sync_test.go
@@ -4,8 +4,11 @@
 package e2e
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"open-cluster-management.io/governance-policy-propagator/controllers/common"
 	"open-cluster-management.io/governance-policy-propagator/test/utils"
@@ -109,5 +112,51 @@ var _ = Describe("Test template sync", func() {
 			false,
 			defaultTimeoutSeconds,
 		)
+	})
+})
+
+var _ = Describe("Test IamPolicy", func() {
+	const (
+		case9PolicyName    string = "case9-iam-test-policy"
+		case9PolicyYaml    string = "../resources/case9_template_sync/case9-iam-policy.yaml"
+		case9IamPolicyName string = "case9-iam-test-policy"
+	)
+
+	BeforeEach(func() {
+		hubApplyPolicy(case9PolicyName, case9PolicyYaml)
+	})
+	AfterEach(func() {
+		By("Deleting a policy on the hub in ns:" + clusterNamespaceOnHub)
+		_, err := kubectlHub("delete", "-f", case9PolicyYaml, "-n", clusterNamespaceOnHub, "--ignore-not-found")
+		Expect(err).ShouldNot(HaveOccurred())
+		opt := metav1.ListOptions{
+			FieldSelector: "metadata.name=" + case9PolicyName,
+		}
+		utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 0, true, defaultTimeoutSeconds)
+
+		kubectlManaged("delete", "event", "-n", clusterNamespace,
+			"--field-selector", "involvedObject.name="+case9PolicyName)
+		utils.ListWithTimeout(
+			clientManagedDynamic,
+			gvrEvent,
+			metav1.ListOptions{FieldSelector: "involvedObject.name=" + case9PolicyName},
+			0,
+			true,
+			defaultTimeoutSeconds)
+	})
+	It("should have a non-support event for IamPolicy", func() {
+		Consistently(func() interface{} {
+			_, err := clientHubDynamic.Resource(gvrIamPolicy).Namespace(clusterNamespace).
+				Get(context.TODO(), case9IamPolicyName, metav1.GetOptions{})
+
+			return errors.IsNotFound(err)
+		}, 5, 1).Should(BeTrue(), "Should not create any IamPolicies")
+
+		eventList, err := clientManaged.CoreV1().Events("").List(context.TODO(),
+			metav1.ListOptions{FieldSelector: "involvedObject.name=" + case9PolicyName + ",reason=PolicyTemplateSync"})
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(eventList.Items).Should(HaveLen(1))
+
+		Expect(eventList.Items[0].Message).Should(Equal("template-error; IamPolicy is no longer supported"))
 	})
 })

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -43,6 +43,7 @@ var (
 	gvrSecret              schema.GroupVersionResource
 	gvrEvent               schema.GroupVersionResource
 	gvrConfigurationPolicy schema.GroupVersionResource
+	gvrIamPolicy           schema.GroupVersionResource
 	gvrConstraintTemplate  schema.GroupVersionResource
 	kubeconfigHub          string
 	kubeconfigManaged      string
@@ -99,6 +100,11 @@ var _ = BeforeSuite(func() {
 		Group:    "policy.open-cluster-management.io",
 		Version:  "v1",
 		Resource: "configurationpolicies",
+	}
+	gvrIamPolicy = schema.GroupVersionResource{
+		Group:    "policy.open-cluster-management.io",
+		Version:  "v1",
+		Resource: "iampolicies",
 	}
 	gvrConstraintTemplate = schema.GroupVersionResource{
 		Group:    "templates.gatekeeper.sh",

--- a/test/resources/case9_template_sync/case9-iam-policy.yaml
+++ b/test/resources/case9_template_sync/case9-iam-policy.yaml
@@ -1,0 +1,24 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: case9-iam-test-policy
+  labels:
+    policy.open-cluster-management.io/cluster-name: managed
+    policy.open-cluster-management.io/cluster-namespace: managed
+    policy.open-cluster-management.io/root-policy: case9-test-policy
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: IamPolicy
+        metadata:
+          name: case9-iam
+        spec:
+          severity: medium
+          namespaceSelector:
+            include: ["*"]
+            exclude: ["kube-*", "openshift-*"]
+          remediationAction: inform
+          maxClusterRoleBindingUsers: 2


### PR DESCRIPTION
Modify the governance-policy-framework-addon's template-sync controller to send a template error compliance event stating it is no longer supported. Confirm with docs on the message.
Ref: https://issues.redhat.com/browse/ACM-10859