### PR TITLE
Send a non-support message for Iam

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -49,7 +49,9 @@
             "program": "${workspaceFolder}/test/e2e/e2e_suite_test.go",
             "args": [
                 "-ginkgo.debug",
-                "-ginkgo.v"
+                "-ginkgo.v",
+                "--kubeconfig_managed=${workspaceFolder}/kubeconfig_managed_e2e",
+                "--kubeconfig_hub=${workspaceFolder}/kubeconfig_hub_e2e",
             ],
             "env": {
                 "KUBECONFIG": "${workspaceFolder}/kubeconfig_managed_e2e"

--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ build:
 
 .PHONY: run
 run:
-	HUB_CONFIG=$(HUB_CONFIG) MANAGED_CONFIG=$(MANAGED_CONFIG) go run ./main.go --leader-elect=false --cluster-namespace=$(MANAGED_CLUSTER_NAME)
+	HUB_CONFIG=$(HUB_CONFIG) MANAGED_CONFIG=$(MANAGED_CONFIG) OSDK_FORCE_RUN_MODE="local" go run ./main.go --leader-elect=false --cluster-namespace=$(MANAGED_CLUSTER_NAME) --cluster-namespace-on-hub=$(MANAGED_CLUSTER_NAME) --log-level=3 --compliance-api-url=http://127.0.0.1:8385 
 
 ############################################################
 # images section

--- a/controllers/templatesync/template_sync.go
+++ b/controllers/templatesync/template_sync.go
@@ -300,6 +300,15 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 			continue
 		}
 
+		if object.GetObjectKind().GroupVersionKind().Kind == "IamPolicy" {
+			errMsg := "IamPolicy is no longer supported"
+
+			_ = r.emitTemplateError(ctx, instance, tIndex, fmt.Sprintf("template-%v", tIndex), false, errMsg)
+
+			reqLogger.Error(resultError, errMsg, "templateIndex", tIndex)
+
+			continue
+		}
 		// Special handling booleans, whether this template is:
 		// - ContraintTemplate handled by Gatekeeper
 		// - Cluster scoped

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -43,6 +43,7 @@ var (
 	gvrSecret              schema.GroupVersionResource
 	gvrEvent               schema.GroupVersionResource
 	gvrConfigurationPolicy schema.GroupVersionResource
+	gvrIamPolicy           schema.GroupVersionResource
 	gvrConstraintTemplate  schema.GroupVersionResource
 	kubeconfigHub          string
 	kubeconfigManaged      string
@@ -99,6 +100,11 @@ var _ = BeforeSuite(func() {
 		Group:    "policy.open-cluster-management.io",
 		Version:  "v1",
 		Resource: "configurationpolicies",
+	}
+	gvrIamPolicy = schema.GroupVersionResource{
+		Group:    "policy.open-cluster-management.io",
+		Version:  "v1",
+		Resource: "iampolicies",
 	}
 	gvrConstraintTemplate = schema.GroupVersionResource{
 		Group:    "templates.gatekeeper.sh",

--- a/test/resources/case9_template_sync/case9-iam-policy.yaml
+++ b/test/resources/case9_template_sync/case9-iam-policy.yaml
@@ -1,7 +1,7 @@
 apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
-  name: case9-test-policy
+  name: case9-iam-test-policy
   labels:
     policy.open-cluster-management.io/cluster-name: managed
     policy.open-cluster-management.io/cluster-namespace: managed
@@ -12,21 +12,13 @@ spec:
   policy-templates:
     - objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1
-        kind: ConfigurationPolicy
+        kind: IamPolicy
         metadata:
-          name: case9-config-policy
+          name: case9-iam
         spec:
+          severity: medium
+          namespaceSelector:
+            include: ["*"]
+            exclude: ["kube-*", "openshift-*"]
           remediationAction: inform
-          object-templates:
-            - complianceType: musthave
-              objectDefinition:
-                apiVersion: v1
-                kind: Pod
-                metadata:
-                  name: nginx-pod-e2e
-                  namespace: default
-                spec:
-                  containers:
-                    - name: nginx
-
-
+          maxClusterRoleBindingUsers: 2


### PR DESCRIPTION
Modify the governance-policy-framework-addon's template-sync controller to send a template error compliance event stating it is no longer supported. Confirm with docs on the message.
Ref: https://issues.redhat.com/browse/ACM-10859