### PR TITLE
[manual-cherrypick-2.10]Fix ConstraintTemplate creation with invalid rego

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -235,7 +235,8 @@ install-resources:
 	-kubectl apply -k deploy/hubpermissions --kubeconfig=$(HUB_CONFIG)_e2e
 	@if [ "$(KIND_VERSION)" != "minimum" ]; then \
 		echo installing Gatekeeper on the managed cluster; \
-		kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper/v3.11.0/deploy/gatekeeper.yaml  --kubeconfig=$(MANAGED_CONFIG)_e2e; \
+		curl -L https://raw.githubusercontent.com/stolostron/gatekeeper/release-3.17/deploy/gatekeeper.yaml | sed 's/- --disable-cert-rotation/- --disable-cert-rotation\n        - --audit-interval=10/g' | kubectl apply --kubeconfig=$(MANAGED_CONFIG)_e2e -f -; \
+		kubectl -n gatekeeper-system wait --for=condition=Available deployment/gatekeeper-audit --kubeconfig=$(MANAGED_CONFIG)_e2e; \
 	fi
 
 .PHONY: e2e-test

--- a/controllers/templatesync/template_sync.go
+++ b/controllers/templatesync/template_sync.go
@@ -588,6 +588,20 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 					continue
 				}
 
+				// Applicable for Gatekeeper versions v3.17 and later.
+				if isGkConstraintTemplate {
+					sentMsg, err := r.emitGKConstraintTemplateErrMsg(ctx, tObjectUnstructured,
+						res, instance, tIndex, tName)
+					if err != nil {
+						return reconcile.Result{}, err
+					}
+
+					if sentMsg {
+						// Skip success event emitting
+						continue
+					}
+				}
+
 				successMsg := fmt.Sprintf("Policy template %s created successfully", tName)
 
 				tLogger.Info("Policy template created successfully")
@@ -644,6 +658,25 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 			policySystemErrorsCounter.WithLabelValues(instance.Name, tName, "get-error").Inc()
 
 			continue
+		}
+
+		// Applicable for Gatekeeper versions v3.17 and later.
+		if isGkConstraintTemplate {
+			sentErrMsg, err := r.emitGKConstraintTemplateErrMsg(ctx, tObjectUnstructured,
+				res, instance, tIndex, tName)
+			if err != nil {
+				return reconcile.Result{}, err
+			}
+
+			if !sentErrMsg {
+				tLogger.Info("Emitting status event for " + gvk.Kind)
+				msg := fmt.Sprintf("%s %s was created successfully", gvk.Kind, tName)
+
+				emitErr := r.emitTemplateSuccess(ctx, instance, tIndex, tName, isClusterScoped, msg)
+				if emitErr != nil {
+					resultError = emitErr
+				}
+			}
 		}
 
 		if len(dependencyFailures) > 0 {
@@ -1014,8 +1047,12 @@ func (r *PolicyReconciler) cleanUpExcessTemplates(
 				r.setCreatedGkConstraint(false)
 			}
 			// Iterate over the ConstraintTemplates to gather the Constraints on the cluster
+			// In Gatekeeper v3.17 and later, ConstraintTemplates are created even if they contain errors.
+			// Only append to tmplGVRs if the ConstraintTemplate's status.created field is true.
 			for _, gkCT := range gkConstraintTemplateListv1.Items {
-				gkCT := gkCT
+				if !gkCT.Status.Created {
+					continue
+				}
 
 				tmplGVRs = append(tmplGVRs, gvrScoped{
 					gvr: schema.GroupVersionResource{
@@ -1678,4 +1715,43 @@ func getDupName(pol *policiesv1.Policy) string {
 	}
 
 	return ""
+}
+
+// emitGKConstraintTemplateErrMsg generates an error message based
+// on the Gatekeeper ConstraintTemplate status.
+// retrieves the "status.created" field from a Gatekeeper ConstraintTemplate.
+// In Gatekeeper 3.17 and later, if a ConstraintTemplate contains a Rego syntax error,
+// it is still created, but its status field will have "created: false" instead of failing outright.
+// Returns true if an error message is emitted.
+func (r *PolicyReconciler) emitGKConstraintTemplateErrMsg(
+	ctx context.Context,
+	tObjectUnstructured *unstructured.Unstructured,
+	res dynamic.ResourceInterface,
+	instance *policiesv1.Policy,
+	tIndex int,
+	tName string,
+) (bool, error) {
+	name := tObjectUnstructured.GetName()
+
+	template, err := res.Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return false, err
+	}
+
+	created, ok, err := unstructured.NestedBool(template.Object, "status", "created")
+	if !ok || err != nil {
+		errMsg := fmt.Sprintf("Failed to retrieve status.created from ConstraintTemplate %s: %v", name, err)
+		_ = r.emitTemplateError(ctx, instance, tIndex, tName, true, errMsg)
+
+		return true, nil
+	}
+
+	if !created {
+		errMsg := fmt.Sprintf("Failed to create Gatekeeper ConstraintTemplate. Check the status of %s.", name)
+		_ = r.emitTemplateError(ctx, instance, tIndex, tName, true, errMsg)
+
+		return true, nil
+	}
+
+	return false, nil
 }

--- a/test/resources/case17_gatekeeper_sync/error-status/policy.yaml
+++ b/test/resources/case17_gatekeeper_sync/error-status/policy.yaml
@@ -1,0 +1,32 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: case17-invalid-syntax
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: templates.gatekeeper.sh/v1
+        kind: ConstraintTemplate
+        metadata:
+          name: case17error
+        spec:
+          crd:
+            spec:
+              names:
+                kind: Case17Error
+          targets:
+            - target: admission.k8s.gatekeeper.sh
+              rego: |
+                package case17error
+
+                violation[{"msg": msg}] {
+                  input.review.object.metadata.name != \"kube-root-ca.crt\"
+                  input.review.object.metadata.name != \"openshift-service-ca.crt\"
+                  provided := {label | input.review.object.metadata.labels[label]}
+                  required := {label | label := input.parameters.labels[_] invalid(missing})
+                  missing := required - provided
+                  count(missing) > 0
+                  msg := sprintf(\"you must provide labels: %v\", [missing])
+                }


### PR DESCRIPTION
Ref: https://issues.redhat.com/browse/ACM-15588
ConstraintTemplate is created and compliant even with invalid rego syntax
Signed-off-by: yiraeChristineKim <yikim@redhat.com>
(cherry picked from commit e758f0480dfa0372a52084d756af741d4c07d998)