### PR TITLE
Migrate Konflux configs for ACM 2.16

### DIFF
--- a/.tekton/governance-policy-framework-addon-acm-216-pull-request.yaml
+++ b/.tekton/governance-policy-framework-addon-acm-216-pull-request.yaml
@@ -8,13 +8,13 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main"
-  creationTimestamp:
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch in ["main", "release-2.16"]
+  creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: release-acm-215
-    appstudio.openshift.io/component: governance-policy-framework-addon-acm-215
+    appstudio.openshift.io/application: release-acm-216
+    appstudio.openshift.io/component: governance-policy-framework-addon-acm-216
     pipelines.appstudio.openshift.io/type: build
-  name: governance-policy-framework-addon-acm-215-on-pull-request
+  name: governance-policy-framework-addon-acm-216-on-pull-request
   namespace: crt-redhat-acm-tenant
 spec:
   params:
@@ -23,7 +23,7 @@ spec:
     - name: revision
       value: '{{revision}}'
     - name: output-image
-      value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/governance-policy-framework-addon-acm-215:on-pr-{{revision}}
+      value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/governance-policy-framework-addon-acm-216:on-pr-{{revision}}
     - name: path-context
       value: .
     - name: dockerfile
@@ -49,7 +49,7 @@ spec:
       - name: pathInRepo
         value: pipelines/common.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-governance-policy-framework-addon-acm-215
+    serviceAccountName: build-pipeline-governance-policy-framework-addon-acm-216
   workspaces:
     - name: git-auth
       secret:

--- a/.tekton/governance-policy-framework-addon-acm-216-push.yaml
+++ b/.tekton/governance-policy-framework-addon-acm-216-push.yaml
@@ -7,13 +7,13 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-2.15"
-  creationTimestamp:
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-2.16"
+  creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: release-acm-215
-    appstudio.openshift.io/component: governance-policy-framework-addon-acm-215
+    appstudio.openshift.io/application: release-acm-216
+    appstudio.openshift.io/component: governance-policy-framework-addon-acm-216
     pipelines.appstudio.openshift.io/type: build
-  name: governance-policy-framework-addon-acm-215-on-push
+  name: governance-policy-framework-addon-acm-216-on-push
   namespace: crt-redhat-acm-tenant
 spec:
   params:
@@ -22,7 +22,7 @@ spec:
     - name: revision
       value: '{{revision}}'
     - name: output-image
-      value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/governance-policy-framework-addon-acm-215:{{revision}}
+      value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/governance-policy-framework-addon-acm-216:{{revision}}
     - name: path-context
       value: .
     - name: dockerfile
@@ -49,7 +49,7 @@ spec:
       - name: pathInRepo
         value: pipelines/common.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-governance-policy-framework-addon-acm-215
+    serviceAccountName: build-pipeline-governance-policy-framework-addon-acm-216
   workspaces:
     - name: git-auth
       secret:


### PR DESCRIPTION
Automated migration via [`migrate-konflux.sh`](https://github.com/stolostron/governance-policy-framework/blob/main/build/branch-create/migrate-konflux.sh) script.

Closes #899