### PR TITLE
[release-2.16] Retry manager creation on startup failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,9 +98,11 @@ lint:
 # test section
 ############################################################
 
+TEST_PKGS ?= ./controllers/statussync ./controllers/secretsync ./controllers/templatesync ./controllers/utils
+
 .PHONY: test
 test: test-dependencies
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test $(TESTARGS) `go list ./... | grep -v test/e2e`
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test $(TESTARGS) $(TEST_PKGS)
 
 .PHONY: test-coverage
 test-coverage: TESTARGS = -json -cover -covermode=atomic -coverprofile=coverage_unit.out

--- a/controllers/utils/retry_manager.go
+++ b/controllers/utils/retry_manager.go
@@ -1,0 +1,116 @@
+// Copyright Contributors to the Open Cluster Management project
+
+package utils
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/go-logr/logr"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+// NewManagerWithRetry creates a controller-runtime manager, retrying on failure so the
+// process does not exit in sub-second on transient startup errors (for example hub DNS
+// unavailable during an SNO reboot), which can trigger CRI-O RunContainerError races.
+//
+// The first failure always triggers one retry after 2s. Further retries (4s, 8s, 16s)
+// continue only while the error looks like a transient connectivity/DNS failure.
+// Returns the last error if all attempts fail, or if the context is cancelled while waiting.
+func NewManagerWithRetry(
+	ctx context.Context, log logr.Logger, cfg *rest.Config, options manager.Options,
+) (manager.Manager, error) {
+	mgr, err := ctrl.NewManager(cfg, options)
+	if err == nil {
+		return mgr, nil
+	}
+
+	for _, wait := range []int{2, 4, 8, 16} {
+		log.Error(err, "Failed to create manager; will retry", "waitSeconds", wait)
+
+		timer := time.NewTimer(time.Duration(wait) * time.Second)
+
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+
+			return nil, fmt.Errorf("aborted while retrying manager creation: %w", ctx.Err())
+		case <-timer.C:
+		}
+
+		mgr, err = ctrl.NewManager(cfg, options)
+		if err == nil {
+			return mgr, nil
+		}
+
+		if !isRetryableManagerStartError(err) {
+			return nil, err
+		}
+	}
+
+	// Getting here means the manager had failures every time
+	return nil, err
+}
+
+// isRetryableManagerStartError reports whether err is a transient reachability failure
+// that may clear without process restart (DNS not ready, connection refused, timeouts).
+func isRetryableManagerStartError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return true
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) && (netErr.Timeout() || temporaryNetError(netErr)) {
+		return true
+	}
+
+	for _, target := range []error{
+		syscall.ECONNREFUSED,
+		syscall.ECONNRESET,
+		syscall.ETIMEDOUT,
+		syscall.ENETUNREACH,
+		syscall.EHOSTUNREACH,
+		io.ErrUnexpectedEOF,
+	} {
+		if errors.Is(err, target) {
+			return true
+		}
+	}
+
+	// Some TLS/HTTP2 failures do not unwrap to syscall errno or net.DNSError.
+	msg := strings.ToLower(err.Error())
+	for _, s := range []string{
+		"tls handshake timeout",
+		"client connection lost",
+	} {
+		if strings.Contains(msg, s) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// temporaryNetError wraps the deprecated Temporary() check so callers stay intentional.
+func temporaryNetError(err net.Error) bool {
+	type temporary interface {
+		Temporary() bool
+	}
+
+	t, ok := err.(temporary)
+
+	return ok && t.Temporary()
+}

--- a/controllers/utils/retry_manager_test.go
+++ b/controllers/utils/retry_manager_test.go
@@ -1,0 +1,128 @@
+// Copyright Contributors to the Open Cluster Management project
+
+package utils
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"syscall"
+	"testing"
+)
+
+func TestIsRetryableManagerStartError(t *testing.T) {
+	t.Parallel()
+
+	dnsErr := &net.DNSError{
+		Err:  "connection refused",
+		Name: "api.example.hub",
+	}
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "non-retryable",
+			err:  errors.New("unable to set up health check"),
+			want: false,
+		},
+		{
+			name: "dns error",
+			err:  dnsErr,
+			want: true,
+		},
+		{
+			name: "wrapped dns error matching ACM-34590",
+			err: fmt.Errorf(
+				"failed to determine if *v1.Secret is namespaced: failed to get restmapping: "+
+					"failed to get server groups: Get \"https://api.example:6443/api\": %w",
+				dnsErr,
+			),
+			want: true,
+		},
+		{
+			name: "non-retryable op error",
+			err: &net.OpError{
+				Op:  "dial",
+				Net: "unix",
+				Err: errors.New("invalid argument"),
+			},
+			want: false,
+		},
+		{
+			name: "connection refused errno",
+			err: &net.OpError{
+				Op:  "dial",
+				Net: "tcp",
+				Err: syscall.ECONNREFUSED,
+			},
+			want: true,
+		},
+		{
+			name: "wrapped connection refused errno",
+			err: fmt.Errorf(
+				"failed to get server groups: Get \"https://api.example:6443/api\": %w",
+				&net.OpError{Op: "dial", Net: "tcp", Err: syscall.ECONNREFUSED},
+			),
+			want: true,
+		},
+		{
+			name: "connection reset errno",
+			err:  syscall.ECONNRESET,
+			want: true,
+		},
+		{
+			name: "timed out errno",
+			err:  syscall.ETIMEDOUT,
+			want: true,
+		},
+		{
+			name: "network unreachable errno",
+			err:  syscall.ENETUNREACH,
+			want: true,
+		},
+		{
+			name: "host unreachable errno",
+			err:  syscall.EHOSTUNREACH,
+			want: true,
+		},
+		{
+			name: "unexpected eof",
+			err:  fmt.Errorf("read response: %w", io.ErrUnexpectedEOF),
+			want: true,
+		},
+		{
+			name: "tls handshake timeout string",
+			err:  errors.New("net/http: TLS handshake timeout"),
+			want: true,
+		},
+		{
+			name: "client connection lost string",
+			err:  errors.New("http2: client connection lost"),
+			want: true,
+		},
+		{
+			name: "connection refused string only is not enough",
+			err:  errors.New("something failed: connection refused"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := isRetryableManagerStartError(tt.err); got != tt.want {
+				t.Fatalf("isRetryableManagerStartError() = %v, want %v (err=%v)", got, tt.want, tt.err)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -238,7 +238,7 @@ func main() {
 	mainCtx := ctrl.SetupSignalHandler()
 	mgrCtx, mgrCtxCancel := context.WithCancel(mainCtx)
 
-	mgr := getManager(mgrOptionsBase, mgrHealthAddr, hubCfg, managedCfg)
+	mgr := getManager(mgrCtx, mgrOptionsBase, mgrHealthAddr, hubCfg, managedCfg)
 
 	var hubMgr manager.Manager
 
@@ -251,7 +251,7 @@ func main() {
 
 		healthAddresses[hubMgrHealthAddr] = true
 
-		hubMgr = getHubManager(mgrOptionsBase, hubMgrHealthAddr, hubCfg, managedCfg)
+		hubMgr = getHubManager(mgrCtx, mgrOptionsBase, hubMgrHealthAddr, hubCfg, managedCfg)
 	}
 
 	healthAddressesLock.Unlock()
@@ -359,7 +359,7 @@ func main() {
 
 // getManager return a controller Manager object that watches on the managed cluster and has the controllers registered.
 func getManager(
-	options manager.Options, healthAddr string, hubCfg *rest.Config, managedCfg *rest.Config,
+	ctx context.Context, options manager.Options, healthAddr string, hubCfg *rest.Config, managedCfg *rest.Config,
 ) manager.Manager {
 	crdLabelSelector := labels.SelectorFromSet(map[string]string{utils.PolicyTypeLabel: "template"})
 
@@ -419,7 +419,7 @@ func getManager(
 		},
 	}
 
-	mgr, err := ctrl.NewManager(managedCfg, options)
+	mgr, err := utils.NewManagerWithRetry(ctx, log, managedCfg, options)
 	if err != nil {
 		log.Error(err, "unable to start manager")
 		os.Exit(1)
@@ -454,7 +454,7 @@ func getManager(
 
 // getHubManager return a controller Manager object that watches on the Hub and has the controllers registered.
 func getHubManager(
-	options manager.Options, healthAddr string, hubCfg *rest.Config, managedCfg *rest.Config,
+	ctx context.Context, options manager.Options, healthAddr string, hubCfg *rest.Config, managedCfg *rest.Config,
 ) manager.Manager {
 	// Set the manager options
 	options.HealthProbeBindAddress = healthAddr
@@ -482,7 +482,7 @@ func getHubManager(
 	options.Metrics.BindAddress = "0"
 
 	// Create a new manager to provide shared dependencies and start components
-	mgr, err := ctrl.NewManager(hubCfg, options)
+	mgr, err := utils.NewManagerWithRetry(ctx, log, hubCfg, options)
 	if err != nil {
 		log.Error(err, "Failed to start manager")
 		os.Exit(1)


### PR DESCRIPTION
Sometimes when the controller-runtime manager fails to be created, the process will exit almost immediately, which can confuse CRI-O/kubelet. This can cause the container to take longer to recover than necessary.

Now, manager creation will always be retried once (after 2 seconds), and errors that are likely to be transient connectivity problems will have additional retries after 4, 8, and 16 additional seconds. After that, the container will fully fail and kubelet can take over the restarts.

Refs:
 - https://issues.redhat.com/browse/ACM-34590

(cherry picked from commit 77145e697ea183dad89e40b50241ec3b53c00dce)

**Cherry-pick note:** The part that would not merge cleanly was the Makefile change. 